### PR TITLE
Allows nornir's user to pass extras parameters to netmiko

### DIFF
--- a/nornir_netmiko/connections/netmiko.py
+++ b/nornir_netmiko/connections/netmiko.py
@@ -55,6 +55,7 @@ class Netmiko:
             parameters["device_type"] = platform
 
         extras = extras or {}
+        extras.update(configuration.user_defined)
         parameters.update(extras)
         connection = ConnectHandler(**parameters)
         self.connection = connection


### PR DESCRIPTION
Hello,

First, thank you for all your work, that's amazing ! ❤️ 

Here I propose a tiny PR that fixes an issue I ran into. 

I had to pass extra parameters to netmiko's `ConnectHandler` from `InitNornir` function.

`netmiko.py` seems to take this use-case into account with `extras` parameter but Nornir never fills `extras` (tried all sorts of things).

However, `nornir` has a `user_defined` parameter that we can leverage.

So this PR simply updates `extras` with `user_defined`.

In my case, this was mandatory to use `nornir_netmiko` (`netmiko_send_command`) with servers (I needed `use_keys: True`) and it now works by simply adding it to InitNornir, for example : 

```
nr = InitNornir(
        runner={
            "plugin": "serial",
        },
        inventory={
            "plugin": "AnsibleInventory",
            "options": {"hostsfile": "hosts"},
        },
        user_defined={"use_keys": True},
    )
```
But it could be use for all sorts of things 😉 


Hope this is clear enough.

Thank you in advance 🙂 