### PR TITLE
Add config_mode var into the task

### DIFF
--- a/nornir_netmiko/tasks/netmiko_send_command.py
+++ b/nornir_netmiko/tasks/netmiko_send_command.py
@@ -8,6 +8,8 @@ def netmiko_send_command(
     command_string: str,
     use_timing: bool = False,
     enable: bool = False,
+    config_mode=False,
+    config_command=None,
     **kwargs: Any
 ) -> Result:
     """
@@ -26,6 +28,9 @@ def netmiko_send_command(
     net_connect = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
     if enable:
         net_connect.enable()
+    if config_mode:
+        cfg_mode_args = (config_command,) if config_command else tuple()
+        net_connect.config_mode(*cfg_mode_args)
     if use_timing:
         result = net_connect.send_command_timing(command_string, **kwargs)
     else:


### PR DESCRIPTION
Hi, 
I've added a variable to let to the user the opportunity to enter in config mode into the task. 
For some devices(e.g: Fortinet), several commands are only available in the config mode and it doesn't make any sense (from my point of vue) to use the task "send_config" just to send a simple command.

What do you think about that ? 

Thanks, 
Regards, 
Sam