### PR TITLE
Add netmiko_ssh_autodetect task

### DIFF
--- a/nornir_netmiko/tasks/__init__.py
+++ b/nornir_netmiko/tasks/__init__.py
@@ -3,6 +3,7 @@ from nornir_netmiko.tasks.netmiko_file_transfer import netmiko_file_transfer
 from nornir_netmiko.tasks.netmiko_save_config import netmiko_save_config
 from nornir_netmiko.tasks.netmiko_send_command import netmiko_send_command
 from nornir_netmiko.tasks.netmiko_send_config import netmiko_send_config
+from nornir_netmiko.tasks.netmiko_ssh_autodetect import netmiko_ssh_autodetect
 
 
 __all__ = (
@@ -11,4 +12,5 @@ __all__ = (
     "netmiko_save_config",
     "netmiko_send_command",
     "netmiko_send_config",
+    "netmiko_ssh_autodetect",
 )

--- a/nornir_netmiko/tasks/netmiko_ssh_autodetect.py
+++ b/nornir_netmiko/tasks/netmiko_ssh_autodetect.py
@@ -1,0 +1,45 @@
+from netmiko import NetmikoAuthenticationException, NetmikoTimeoutException
+from netmiko.ssh_autodetect import SSHDetect
+from nornir.core.task import Task, Result
+
+def netmiko_ssh_autodetect(task: Task, update_platform : bool = False) -> Result:
+    """ Uses Netmiko guesser to determine device type
+    
+    Arguments:
+        update_platform: Update host.platform with best guess (default False)
+
+    Returns:
+        Result object with the following attributes set:
+          * result (``str``): string with guessed operating system
+          * changed (``bool``): always False.
+          * failed (``bool``): True if any Netmiko Exception occurs
+    
+    """
+    connection = {
+        "host"       : task.host.hostname,
+        "username"   : task.host.username,
+        "password"   : task.host.password,
+        "port"       : task.host.port,
+        "device_type": 'autodetect'
+    }
+
+    try:
+        guesser = SSHDetect(**connection)
+        best_match = guesser.autodetect()
+    except (NetmikoAuthenticationException, NetmikoTimeoutException):
+        return Result(
+            host=task.host,
+            changed=True,
+            failed=True,)
+
+    # Updates the current host's platform. Useful if this task 
+    # is the first one in a sequence of network mapping tasks
+    # that require host.platform to be set later on.
+    if update_platform:
+        task.host.platform = best_match
+
+    return Result(
+        host=task.host,
+        result=best_match,
+        changed= False
+    )


### PR DESCRIPTION
Made this little task that uses SSHDetect to guess the network OS for a bunch of devices in my network. Task works on a regular nornir inventory, returning a Result with the guessed device_type for each host in the result field (there is also a flag that allows hosts to be updated at runtime). Since this uses netmiko directly I guess it makes sense to submit it as part of this plugin.

Thanks!