### PR TITLE
add: support to load extra netmiko platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,33 @@ router1:
         secret: secret
         session_log: router1.txt
 ```
+
+### Extra Netmiko platforms
+
+Netmiko does not easily let you add new custom platforms, thus a custom injection mechanism is provided via the `nornir_netmiko` plugin. To add a new platform, you need to provide `netmiko_extra_platforms` dictionnary, in the `user_defined` configuration of `InitNornir`. The key represent the platform name, while the value is the class to use.
+
+```python
+
+# Create a new device_type derived from linux
+from netmiko.linux.linux_ssh import LinuxSSH,
+
+class CustomSSH(LinuxSSH):
+    "Override LinuxSSH"
+
+    def _build_ssh_client(self) -> SSHClient:
+        """Allow passwordless authentication for HP devices being provisioned."""
+
+        print("Hello World from CustomSSH")
+        return super()._build_ssh_client()
+
+
+
+# When instanciating Nornir, just provide a mapping
+nr = InitNornir(
+    user_defined= {
+        "netmiko_extra_platforms": {
+                "linux_embedded": CustomSSH,
+            }
+        }
+    )
+```

--- a/nornir_netmiko/connections/netmiko.py
+++ b/nornir_netmiko/connections/netmiko.py
@@ -64,8 +64,12 @@ class Netmiko:
 
         device_type = parameters["device_type"]
         connect_handler_cls = ConnectHandler
-        connect_handlers_map = configuration.user_defined.get("netmiko_extra_platforms", {})
-        assert isinstance(connect_handlers_map, dict), f"netmiko_extra_platforms must be a dict, got {type(connect_handlers_map)}"
+        connect_handlers_map = configuration.user_defined.get(
+            "netmiko_extra_platforms", {}
+        )
+        assert isinstance(
+            connect_handlers_map, dict
+        ), f"netmiko_extra_platforms must be a dict, got {type(connect_handlers_map)}"
         if device_type in connect_handlers_map:
             # If user provided a custom device_type, then directly use it and bypass
             # original ConnectHandler function.
@@ -75,8 +79,10 @@ class Netmiko:
             # to let the user being notified of the actual platform list.
             if device_type not in platforms:
                 extra_platforms = list(connect_handlers_map.keys())
-                platform_names = '\n'.join(sorted(platforms + extra_platforms))
-                raise ValueError(f"Unsupported device_type: {device_type}, currently supported platforms are:\n{platform_names}")
+                platform_names = "\n".join(sorted(platforms + extra_platforms))
+                raise ValueError(
+                    f"Unsupported device_type: {device_type}, currently supported platforms are:\n{platform_names}"
+                )
 
         extras = extras or {}
         parameters.update(extras)

--- a/nornir_netmiko/connections/netmiko.py
+++ b/nornir_netmiko/connections/netmiko.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional
 
 from netmiko import ConnectHandler
+from netmiko.ssh_dispatcher import platforms
 
 from nornir.core.configuration import Config
 
@@ -54,9 +55,32 @@ class Netmiko:
             platform = napalm_to_netmiko_map.get(platform, platform)
             parameters["device_type"] = platform
 
+        # Allow nornir_netmiko to load extra platforms/device_types
+        # See https://github.com/ktbyers/netmiko/issues/3252
+        # There is no easy way to inject a new netmiko device_type, so we
+        # completely skip the original ConnectHandler function. This makes
+        # the extra platform only available via nornir_netmiko. Since this
+        # is a tightly coupled integration, it should not be an issue.
+
+        device_type = parameters["device_type"]
+        connect_handler_cls = ConnectHandler
+        connect_handlers_map = configuration.user_defined.get("netmiko_extra_platforms", {})
+        assert isinstance(connect_handlers_map, dict), f"netmiko_extra_platforms must be a dict, got {type(connect_handlers_map)}"
+        if device_type in connect_handlers_map:
+            # If user provided a custom device_type, then directly use it and bypass
+            # original ConnectHandler function.
+            connect_handler_cls = connect_handlers_map[device_type]
+        else:
+            # Ensure device exists in netmiko package. We want
+            # to let the user being notified of the actual platform list.
+            if device_type not in platforms:
+                extra_platforms = list(connect_handlers_map.keys())
+                platform_names = '\n'.join(sorted(platforms + extra_platforms))
+                raise ValueError(f"Unsupported device_type: {device_type}, currently supported platforms are:\n{platform_names}")
+
         extras = extras or {}
         parameters.update(extras)
-        connection = ConnectHandler(**parameters)
+        connection = connect_handler_cls(**parameters)
         self.connection = connection
 
     def close(self) -> None:


### PR DESCRIPTION
Hi there,

Here is my take on supporting custom Netmiko platforms. After trying to find the best implementation approach, and since Netmiko is not easily patchable, I decided to implement the injection mechanism during the `nornir_netmiko` plugin init phase. If a custom class is provided, then it completely bypass (the quite useless) `ConnectHandler`, to directly instantiate the custom class instead.

Related discussion:
  * https://github.com/ktbyers/netmiko/issues/3252 

Use cases:
  * I'm working on automating my openwrt devices with nornir. But I struggle to make nornir to work when working on ssh passwordless devices (which happens when a device is initially installed). Thus I created a custom class that correctly handle the authentication, and now I want to use it in my project.


Side note:
  * It's so sad that Netmiko upstream project does not allow custom platform injection with an API. Also, the passwordless issue has been reported many times in Netmiko bug tracker, without never beeing addressed. Now, I feel more confident to solve the problem via nornir instead.
  * I found many threads of people having issues with Netmiko authentication. By letting `nornir_netmiko` to load custom `device_type` will bring to the nornir community what netmiko project failed to provide to its own users.
  * Eventually we would remove this feature when the Netmiko project will provide a public injection mechanism.

Feel free to comment, improve, discuss or challenge this PR :)